### PR TITLE
* hdf5utils groupname ~ beamformerrecipes. suffix

### DIFF
--- a/src/hdf5utils.jl
+++ b/src/hdf5utils.jl
@@ -51,7 +51,13 @@ isstoreworthy(x::AbstractArray) = sizeof(x) > 0
 
 Name of HDF5 group that holds datasets for `typeof(info)` structs.
 """
-groupname(info::Info) = "/$(lowercase(string(typeof(info))))"
+function groupname(info::Info)
+    datasetpath = "$(lowercase(string(typeof(prop))))"
+    if datasetpath[1:18] == "beamformerrecipes."
+        datasetpath = datasetpath[19:end]
+    end
+    datasetpath = "/$(datasetpath)"
+end
 
 """
     to_hdf5(group::HDF5.Group, info::Info; allopts...)

--- a/src/hdf5utils.jl
+++ b/src/hdf5utils.jl
@@ -52,7 +52,7 @@ isstoreworthy(x::AbstractArray) = sizeof(x) > 0
 Name of HDF5 group that holds datasets for `typeof(info)` structs.
 """
 function groupname(info::Info)
-    datasetpath = "$(lowercase(string(typeof(prop))))"
+    datasetpath = "$(lowercase(string(typeof(info))))"
     if datasetpath[1:18] == "beamformerrecipes."
         datasetpath = datasetpath[19:end]
     end


### PR DESCRIPTION
I recently started encountering the issue where BeamformerRecipes.DimInfo is returned by typeof instead of DimInfo. I don't know that Julia got updated, and cannot fathom why this is occurring... anyway, that rendered the BFR5 files broken. So here is the dummie's solution...